### PR TITLE
Feat/scroll 무한스크롤 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react": "18.2.12",
     "@types/react-dom": "18.2.5",
     "autoprefixer": "10.4.14",
+    "axios": "^1.4.0",
     "eslint": "8.42.0",
     "eslint-config-next": "13.4.6",
     "mongodb": "^5.6.0",

--- a/src/app/artist/page.tsx
+++ b/src/app/artist/page.tsx
@@ -1,17 +1,25 @@
 "use client";
 
 import ArtistList from "@/components/ArtistList";
+import ArtistInfiniteScroll from "@/components/ArtistInfiniteScroll";
 import SearchBox from "@/components/SearchBox";
 import Title from "@/components/common/Title";
 import React, { useState } from "react";
 
 export default function Page() {
   const [keyword, setKeyword] = useState<string | null>("");
+
   return (
     <div>
       <SearchBox setKeyword={setKeyword} />
+      {keyword && (
+        <>
+          <Title>{keyword} 검색 결과</Title>
+          <ArtistList keyword={keyword} />
+        </>
+      )}
       <Title>All Artists</Title>
-      <ArtistList keyword={keyword} />
+      <ArtistInfiniteScroll />
     </div>
   );
 }

--- a/src/components/ArtistInfiniteScroll.tsx
+++ b/src/components/ArtistInfiniteScroll.tsx
@@ -1,0 +1,19 @@
+import ArtistCard from "./ArtistCard";
+import useInfiniteScroll from "@/hooks/useInfiniteScroll";
+import { ArtistData } from "./ArtistList";
+
+const ArtistInfiniteScroll = () => {
+  const artists = useInfiniteScroll<ArtistData>({ apiUrl: "/api/artist" });
+
+  return (
+    <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+      {artists?.map((artist) => (
+        <li key={artist._id}>
+          <ArtistCard artist={artist} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ArtistInfiniteScroll;

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,45 @@
+import useSWRInfinite from "swr/infinite";
+import axios from "axios";
+import { useEffect } from "react";
+
+interface InfiniteScrollParam<T> {
+  apiUrl: string;
+}
+
+const useInfiniteScroll = <T>({ apiUrl }: InfiniteScrollParam<T>) => {
+  const getKey = (page: number, previousPageData: any) => {
+    if (previousPageData && !previousPageData.length) return null;
+
+    if (page === 0) return `${apiUrl}?page=1&size=10`;
+    return `${apiUrl}?page=${page + 1}&size=10`;
+  };
+
+  const fetcher = async (url: string) => {
+    const res = await axios.get(url);
+    return res.data;
+  };
+
+  const { data, setSize } = useSWRInfinite<T>(
+    (page, previousPageData) => getKey(page, previousPageData),
+    fetcher,
+    { parallel: true }
+  );
+  const renderedData = data ? ([] as T[]).concat(...data) : [];
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+        setSize((prevSize) => prevSize + 1);
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [setSize]);
+
+  return renderedData;
+};
+
+export default useInfiniteScroll;

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,6 +424,11 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@10.4.14:
   version "10.4.14"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.14.tgz#e28d49902f8e759dd25b153264e862df2705f79d"
@@ -445,6 +450,15 @@ axe-core@^4.6.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
+
+axios@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.1.1:
   version "3.2.1"
@@ -625,6 +639,13 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -725,6 +746,11 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -1175,12 +1201,26 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.2.0:
   version "4.2.0"
@@ -1778,6 +1818,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2282,6 +2334,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
#1 

- [x]  무한스크롤 hook 작성.

```ts
const data명 = useInfiniteScroll<데이터타입>({apiUrl: "api경로"})
```
이런식으로 사용하면 됩니다. 이때 api경로는 
* GET - 아티스트 가져오기 - /api/artist?page={}&size={}
위의 형식일 때 '/api/artist'로 ? 이전까지 작성해서 넘겨주면 돼요.

- [x]  아티스트 무한스크롤 적용

검색어 키워드로 나오는 정보는 '{keyword} 검색 결과' 이런식으로 타이틀이 나오고 필터링된 결과가 나오게 했고,
그 아래에 'All Artist' 타이틀과 함께 무한스크롤 정보도 나오도록 했어요.

- [x]  일단 기능만 넣어뒀고, 추후에 레이아웃을 다시 해야 할 것 같아요.

이 부분은 브라우저 너비에 따라 하트가 짤리는 문제 해결할때 같이 만지면 될듯 합니다.