### PR TITLE
Feat/pagination 페이지네이션 컴포넌트

### DIFF
--- a/src/app/artist/page.tsx
+++ b/src/app/artist/page.tsx
@@ -12,14 +12,17 @@ export default function Page() {
   return (
     <div>
       <SearchBox setKeyword={setKeyword} />
-      {keyword && (
+      {keyword ? (
         <>
           <Title>{keyword} 검색 결과</Title>
           <ArtistList keyword={keyword} />
         </>
+      ) : (
+        <>
+          <Title>All Artists</Title>
+          <ArtistInfiniteScroll />
+        </>
       )}
-      <Title>All Artists</Title>
-      <ArtistInfiniteScroll />
     </div>
   );
 }

--- a/src/components/atoms/Pagination.tsx
+++ b/src/components/atoms/Pagination.tsx
@@ -1,0 +1,66 @@
+import { BsChevronLeft, BsChevronRight } from "react-icons/bs";
+
+interface PaginationProps {
+  page: number;
+  lastPage: number | null;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export default function Pagination({
+  page,
+  lastPage,
+  setPage,
+}: PaginationProps) {
+  return (
+    <div
+      className="flex items-center justify-center space-x-2 mt-16"
+      aria-label="Pagination"
+    >
+      <button
+        className={`${page === 1 ? "cursor-not-allowed" : "cursor-pointer"}`}
+        onClick={() => setPage(page - 1)}
+        disabled={page === 1}
+      >
+        <span className="sr-only">Previous</span>
+        <BsChevronLeft aria-hidden="true" />
+      </button>
+      {lastPage ? (
+        Array(lastPage)
+          .fill(null)
+          .map((_, i) => {
+            return (
+              <button
+                key={i}
+                aria-current="page"
+                className="relative z-10 inline-flex items-center bg-purple-700 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                onClick={() => {
+                  setPage(i + 1);
+                }}
+              >
+                {i + 1}
+              </button>
+            );
+          })
+      ) : (
+        <button
+          aria-current="page"
+          className="relative z-10 inline-flex items-center bg-purple-700 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        >
+          {page}
+        </button>
+      )}
+      <button
+        className={`${
+          page === lastPage ? "cursor-not-allowed" : "cursor-pointer"
+        }`}
+        onClick={() => {
+          setPage(page + 1);
+        }}
+        disabled={page === lastPage}
+      >
+        <span className="sr-only">Next</span>
+        <BsChevronRight aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/organisms/ArtistList.tsx
+++ b/src/components/organisms/ArtistList.tsx
@@ -1,9 +1,10 @@
 "use client";
 import Artist from "@/service/artist/Artist";
 import { ArtistData } from "@/types/_type";
-import React, { useState } from "react";
-import useSWR from "swr";
+import React, { useEffect, useState } from "react";
+import useSWR, { mutate } from "swr";
 import ArtistWrap from "../ArtistWrap";
+import Pagination from "../atoms/Pagination";
 
 export interface ArtistListProps {
   keyword: string | null;
@@ -12,31 +13,41 @@ export default function ArtistList({ keyword }: ArtistListProps) {
   const [page, setPage] = useState(1);
 
   const artistApi = new Artist();
+
   const params = {
     name: keyword,
     page,
     size: 10,
   };
 
+  useEffect(() => {
+    mutate(`api/artist/search/${keyword}`, page);
+  }, [keyword, page]);
+
   const { data, error, isLoading } = useSWR(
     `api/artist/search/${keyword}`,
-    () => artistApi.getSearchArtists(params)
+    () => {
+      return artistApi.getSearchArtists(params);
+    },
+    {
+      revalidateOnMount: page !== 1,
+    }
   );
 
   const artists: ArtistData[] = data && data.data;
-
-  // const filteredArtists = artists?.filter((artist) => {
-  //   const korKeyword = artist.korName.includes(keyword || "");
-  //   const enKeyword = artist.enName.includes(keyword || "");
-  //   return korKeyword || enKeyword;
-  // });
+  const lastPage = null; //총 페이지 수 혹은 총 데이터 수
 
   return (
     <section className=" mt-8">
       {isLoading && <p>loading...</p>}
       {error && <p>error!!!</p>}
       <ArtistWrap artists={artists} />
-      {artists && artists.length === 0 && <p className="text-xl text-gray-400 font-bold text-center">찾고계신 가수가 없네요🥹</p> }
+      {artists && artists.length === 0 && (
+        <p className="text-xl text-gray-400 font-bold text-center">
+          찾고계신 가수가 없네요🥹
+        </p>
+      )}
+      <Pagination setPage={setPage} page={page} lastPage={lastPage} />
     </section>
   );
 }


### PR DESCRIPTION
#18 

- [x] 페이지네이션 컴포넌트
아직 미완. `< | 현재페이지 | >` 형태임.
전체 페이지를 받아올 수 있을 때 수정 예정.
### 사용법
```ts
//1. 페이지네이션 컴포넌트는 page(현재 페이지) setPage, lastPage를 받습니다.
const [page, setPage] = useState(1); //2. page를 상태로 관리
const lastPage = null; //3. 총 페이지 수 혹은 총 데이터 수. 현재는 null로 처리해 둔 상태

  useEffect(() => {
    mutate(`api/artist/search/${keyword}`, page);
  }, [keyword, page]); //4. keyword, page가 바뀔 때마다 렌더링합니다.

  const { data, error, isLoading } = useSWR(
    `api/artist/search/${keyword}`,
    () => {
      return artistApi.getSearchArtists({
    name: keyword,
    page,
    size: 10,
  });
    },
    {
      revalidateOnMount: page !== 1, //5. 컴포넌트가 마운트되었을 때 자동 갱신. (page가 1이 아닐 때 갱신)
    }
  );

<Pagination page={page} setPage={setPage} lastPage={lastPage} />
```


- [x] 키워드 검색시 검색 결과만 나오도록 수정