### PR TITLE
Design: #54 콘서트 디테일 모바일 반응형 대응

### DIFF
--- a/src/app/consert/[slug]/page.tsx
+++ b/src/app/consert/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { DetailDataProps } from "@/types/props";
 const ConcertDetailsPage = ({ params }: { params: DetailDataProps }) => {
   const concertId = params.slug;
   return (
-    <div className="mt-8">
+    <div>
       <ConcertInfo concertId={concertId} />
     </div>
   );

--- a/src/components/organisms/ConcertTabbar.tsx
+++ b/src/components/organisms/ConcertTabbar.tsx
@@ -8,7 +8,7 @@ const ConcertTabbar = ({ concertData }: { concertData: ConcertData }) => {
   const { curIndex, curItem, changeItem } = useTab({ init: 0, tabList });
 
   return (
-    <div className="w-2/4 mr-8">
+    <div className="sm:w-2/4 sm:mr-8 bg-black w-full z-10 rounded-lg">
       <Tabbar tabItems={tabList} curIndex={curIndex} changeItem={changeItem} />
       {curItem === "공연" && (
         <>

--- a/src/components/templetes/ConcertInfo.tsx
+++ b/src/components/templetes/ConcertInfo.tsx
@@ -30,17 +30,22 @@ const ConcertInfo = ({ concertId }: { concertId: string }) => {
     <section>
       {data ? (
         <>
-          <article className="m-8">
+          <article className="p-8">
             <Title>{data?.title}</Title>
-            <div className="flex w-full justify-around">
+            <div className="flex w-full flex-col-reverse sm:flex-row">
               <ConcertTabbar concertData={data} />
-              <div className="w-2/4">
-                <figure className="relative w-full h-screen max-w-md">
+              <div className="sm:w-2/4 w-full sticky top-0">
+                <figure
+                  className="relative w-full h-screen sm:max-w-md"
+                  style={{
+                    height: `calc(100vh - 150px)`,
+                  }}
+                >
                   <Image
                     src={data?.image}
                     alt={data?.title}
                     fill={true}
-                    className="sticky top-0 object-contain object-top"
+                    className="object-contain object-top"
                   />
                 </figure>
               </div>


### PR DESCRIPTION
* 테일윈드에서 정의하는 sm(640px)을 분기로 잡았습니다.
* 640px 이하일 때 이미지가 먼저 나오고 스크롤시 콘서트 정보가 이미지 위로 올라오는 형태입니다.