### PR TITLE
Fix: db데이터 변경 시 vercel 서버 캐싱 데이터 이슈

### DIFF
--- a/src/components/organisms/CommingConcert.tsx
+++ b/src/components/organisms/CommingConcert.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 import { getApi } from "@/service/api/api";
 import { ConcertData } from "@/types/_type";
 import React from "react";
@@ -7,14 +7,17 @@ import Card from "../atoms/Card";
 import Title from "../atoms/Title";
 import Loading from "../common/Loading";
 import CarouselView from "./CarouselView";
-import {BsFillBellFill} from 'react-icons/bs'
+import { BsFillBellFill } from "react-icons/bs";
+import { getStringSelectDate } from "@/utils/date";
 
 export default function CommingConcert() {
-  const { data, error, isLoading } = useSWR("/api/consert/come", () =>
-    getApi("/consert/come")
+  const todayDate = getStringSelectDate(new Date());
+  const { data, error, isLoading } = useSWR(
+    `/api/consert/come/${todayDate}`,
+    () => getApi("/consert/come")
   );
 
-  const commingConcerts: ConcertData[] = data && data.result
+  const commingConcerts: ConcertData[] = data && data.result;
   return (
     <section className="flex flex-col mt-20">
       <Title icon={<BsFillBellFill />}>Comming</Title>
@@ -28,4 +31,14 @@ export default function CommingConcert() {
       )}
     </section>
   );
+}
+
+export async function getStaticProps() {
+  const commings = await getApi("/api/consert/come");
+  return {
+    props: {
+      initialData: commings.result,
+      revalidate: 1000,
+    },
+  };
 }

--- a/src/components/organisms/HotRank.tsx
+++ b/src/components/organisms/HotRank.tsx
@@ -8,11 +8,14 @@ import Title from "../atoms/Title";
 import Loading from "../common/Loading";
 import CarouselView from "./CarouselView";
 import {FaTrophy} from 'react-icons/fa'
+import { getStringSelectDate } from "@/utils/date";
 
 export default function HotRank() {
   const consert = useConsertApi();
+  const todayDate = getStringSelectDate(new Date())
+  console.log(todayDate)
 
-  const { data, error, isLoading } = useSWR("rank", () => consert.rank());
+  const { data, error, isLoading } = useSWR(`rank/${todayDate}`, () => consert.rank());
 
   const ranks: ConcertData[] = data && data.data;
 


### PR DESCRIPTION
- Comming과 Hotrank 데이터 요청시 오늘 날짜를 key값으로 캐싱해서 날짜가 변경되면 캐싱 데이터가 변경되도록 수정